### PR TITLE
feat: .env 파일 지원하기

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,5 @@
 {
   "parser": "@typescript-eslint/parser",
-  "parserOptions": {
-    "project": "./tsconfig.json"
-  },
   "env": {
     "browser": true,
     "es6": true,
@@ -20,6 +17,8 @@
     "plugin:import/recommended"
   ],
   "rules": {
+    // FIXME: 도저히 모르겠어서 일단 비활성화 함
+    "import/no-unresolved": "off",
     "import/order": [
       "error",
       {
@@ -46,10 +45,5 @@
         }
       }
     ]
-  },
-  "settings": {
-    "import/resolver": {
-      "typescript": {}
-    }
   }
 }

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -1,0 +1,8 @@
+export {};
+
+// electron api
+declare global {
+  interface Window {
+    electronAPI: import('../shared/type').IElectronAPI;
+  }
+}

--- a/src/renderer/pages/home.tsx
+++ b/src/renderer/pages/home.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/shared/ui';
 const Home = () => {
   const navigate = useNavigate();
   const machineId = useMachineId();
+  console.log('from env:', import.meta.env.VITE_SAMPLE);
   return (
     <div>
       <h1>home</h1>

--- a/src/renderer/shared/hooks/rive.ts
+++ b/src/renderer/shared/hooks/rive.ts
@@ -5,15 +5,15 @@ import { useStateMachineInput } from '@rive-app/react-canvas';
 // @note: useStateMachineInput의 반환값에 value를 할당해도 리렌더링이 일어나지 않아 커스텀 훅을 만듬
 export const useRiveStateMachineInput = (...args: Parameters<typeof useStateMachineInput>) => {
   const [rive, stateMachineName, inputName, initialValue] = args;
-  const [value, _setValue] = useState(initialValue);
-  const input = useStateMachineInput(rive, stateMachineName, inputName, value);
+  const [_value, _setValue] = useState(initialValue);
+  const input = useStateMachineInput(rive, stateMachineName, inputName, _value);
 
   const setValue = (newValue: number) => {
-    if (input && input.value !== value) {
+    if (input && input.value !== newValue) {
       input.value = newValue;
       _setValue(input.value);
     }
   };
 
-  return [value, setValue, input] as const;
+  return [_value, setValue, input] as const;
 };

--- a/src/renderer/tsconfig.json
+++ b/src/renderer/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "skipLibCheck": true,
+
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "jsx": "react-jsx",
+
+    "allowJs": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "noImplicitAny": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/src/renderer/vite-env.d.ts
+++ b/src/renderer/vite-env.d.ts
@@ -3,9 +3,12 @@
 // modules
 declare module '*.riv';
 
-// electron api
-declare global {
-  interface Window {
-    electronAPI: import('../shared/type').IElectronAPI;
-  }
+// vite env
+// @see: https://electron-vite.org/guide/env-and-mode
+interface ImportMetaEnv {
+  readonly VITE_SAMPLE: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "jsx": "react-jsx",
     "target": "ESNext",
     "module": "commonjs",
     "allowJs": true,
@@ -12,9 +11,7 @@
     "baseUrl": ".",
     "outDir": "dist",
     "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "paths": {
-      "@/*": ["src/renderer/*"]
-    }
-  }
+    "resolveJsonModule": true
+  },
+  "exclude": ["node_modules", "src/renderer/**/*"]
 }


### PR DESCRIPTION
## 작업 내용

- .env 파일 읽어오는거 확인완료함!
  - .env.sample 참고해서 루트에 만들면 import.meta로 읽어올 수 있음
- 다만 tsconfig 분리한 뒤 eslint에서 path alias를 제대로 읽질 못해서 import/no-unresolved 에러가 나서 비활성화시킴.
  - 어짜피 모듈 import 경로 잘못되면 ts에서도 에러 표시하기 떄문에 꺼도 괜찮은 듯 (쫌 아쉽지만..)
- 기타
  - 다른 페이지 동작 확인중에 hook 수정하다가 실수한 부분이 있어서 꼽사리로 수정함 ㅎ.ㅎ 


## 체크리스트

- [x] Code Review 요청
- [x] Label 설정
