### PR TITLE
fix: 다음 집중/휴식시간 조정시 무조건 minus되는거 수정

### DIFF
--- a/src/renderer/pages/home.tsx
+++ b/src/renderer/pages/home.tsx
@@ -19,8 +19,10 @@ const Home = () => {
 
   useEffect(() => {
     if (!user) return;
-    if (!isCompletedOnboarding) return navigate(PATH.ONBOARDING);
-    if (!user.cat) return navigate(PATH.SELECTION);
+    if (!user.cat) {
+      if (!isCompletedOnboarding) return navigate(PATH.ONBOARDING);
+      return navigate(PATH.SELECTION);
+    }
     navigate(PATH.POMODORO);
   }, [isCompletedOnboarding, user]);
 

--- a/src/renderer/widgets/pomodoro/ui/rest-screen.tsx
+++ b/src/renderer/widgets/pomodoro/ui/rest-screen.tsx
@@ -85,7 +85,7 @@ export const RestScreen = ({
           >
             <SelectGroupItem
               disabled={currentRestMinutes - MINUTES_GAP <= MIN_REST_MINUTES}
-              value="minus-focus-time"
+              value="minus"
               className="flex flex-row items-center justify-center gap-1 px-3 py-2"
             >
               <Icon name="minusSvg" size="sm" className="[&>path]:stroke-icon-tertiary" />
@@ -93,7 +93,7 @@ export const RestScreen = ({
             </SelectGroupItem>
             <SelectGroupItem
               disabled={currentRestMinutes + MINUTES_GAP >= MAX_REST_MINUTES}
-              value="plus-focus-time"
+              value="plus"
               className="flex flex-row items-center justify-center gap-1 px-3 py-2"
             >
               <Icon name="plusSvg" size="sm" className="[&>path]:stroke-icon-tertiary" />

--- a/src/renderer/widgets/pomodoro/ui/rest-wait-screen.tsx
+++ b/src/renderer/widgets/pomodoro/ui/rest-wait-screen.tsx
@@ -88,7 +88,7 @@ export const RestWaitScreen = ({
           >
             <SelectGroupItem
               disabled={currentFocusMinutes - MINUTES_GAP <= MIN_FOCUS_MINUTES}
-              value="minus-focus-time"
+              value="minus"
               className="flex flex-row items-center justify-center gap-1 px-3 py-2"
             >
               <Icon name="minusSvg" size="sm" className="[&>path]:stroke-icon-tertiary" />
@@ -96,7 +96,7 @@ export const RestWaitScreen = ({
             </SelectGroupItem>
             <SelectGroupItem
               disabled={currentFocusMinutes + MINUTES_GAP >= MAX_FOCUS_MINUTES}
-              value="plus-focus-time"
+              value="plus"
               className="flex flex-row items-center justify-center gap-1 px-3 py-2"
             >
               <Icon name="plusSvg" size="sm" className="[&>path]:stroke-icon-tertiary" />


### PR DESCRIPTION
## 작업 내용

- 다음 집중/휴식시간 변경 버튼 클릭시 어떤 선택을 해도 minus되는거 수정
- 고양이 선택하지 않은 유저만 온보딩페이지로 넘어갈 수 있도록 수정
  - 개발시 가끔 localstorage가 비는데 온보딩 -> 고양이 선택으로 넘어가는 플로우가 이상해서 수정함 

## 체크리스트

- [x] Code Review 요청
- [x] Label 설정
