### PR TITLE
fix: 시간 계산하는 로직 일부 수정

### DIFF
--- a/src/renderer/entities/pomodoro/types.ts
+++ b/src/renderer/entities/pomodoro/types.ts
@@ -13,14 +13,21 @@ export type PomodoroNextAction = 'plus' | 'minus';
 export type PomodoroEndReason = 'manual' | 'exceed';
 
 export type PomodoroCycle = {
+  /* 시작 시각 */
   startAt: number;
+  /* 종료 시각. 현재 cycle이 종료되지 않았다면 undefined */
   endAt?: number;
+  /* 목표 시간 */
   goalTime: number;
+  /* 초과 시간 */
   exceedMaxTime: number;
+  /* 모드 */
   mode: PomodoroMode;
 };
 
 export type PomodoroTime = {
+  /* 지난 시간. 값의 범위: 0 <= elapsed <= cycle.goalTime + cycle.exceedMaxTime */
   elapsed: number;
+  /* 초과 시간. 값의 범위: 0 <= exceeded <= cycle.exceedMaxTime */
   exceeded: number;
 };

--- a/src/renderer/features/pomodoro/hooks/use-pomodoro.ts
+++ b/src/renderer/features/pomodoro/hooks/use-pomodoro.ts
@@ -66,8 +66,9 @@ const updateCycles = (cycles: PomodoroCycle[], nextCycle?: PomodoroCycle): Pomod
 
 export const getPomodoroTime = (cycle: PomodoroCycle): PomodoroTime => {
   const now = cycle.endAt ?? Date.now();
-  const elapsed = now - cycle.startAt;
-  const exceeded = elapsed - cycle.goalTime;
+  const maxElapsedTime = cycle.goalTime + cycle.exceedMaxTime;
+  const elapsed = Math.min(maxElapsedTime, now - cycle.startAt);
+  const exceeded = Math.min(cycle.exceedMaxTime, elapsed - cycle.goalTime);
 
   return { elapsed, exceeded };
 };

--- a/src/renderer/pages/pomodoro.tsx
+++ b/src/renderer/pages/pomodoro.tsx
@@ -80,10 +80,8 @@ const Pomodoro = () => {
 
         cycles.forEach((cycle) => {
           const time = getPomodoroTime(cycle);
-          if (cycle.mode === 'focus')
-            focusedTime += Math.min(time.elapsed, cycle.goalTime + cycle.exceedMaxTime);
-          if (cycle.mode === 'rest')
-            restedTime += Math.min(time.elapsed, cycle.goalTime + cycle.exceedMaxTime);
+          if (cycle.mode === 'focus') focusedTime += time.elapsed;
+          if (cycle.mode === 'rest') restedTime += time.elapsed;
         });
 
         if (focusedTime < 1000 * 60) {

--- a/src/renderer/shared/ui/dialog.tsx
+++ b/src/renderer/shared/ui/dialog.tsx
@@ -41,7 +41,7 @@ export const Dialog = ({
             fullScreen && 'fixed bottom-0 left-[50%] top-0 translate-x-[-50%] pt-[56px]',
             !fullScreen &&
               'fixed left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%] rounded-md p-[20px] shadow-lg',
-            'z-50 w-full max-w-md bg-background-primary',
+            'z-50 w-[95%] max-w-md bg-background-primary',
 
             animated &&
               'duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',


### PR DESCRIPTION
## 작업 내용

- 지난 시간과 초과 시간이 현재시각의 diff로 계산하다보니 최대값보다 커지는 경우가 있어서
- 아예 계산되는 값을 특정 값을 넘어갈 수 없게 변경함
  - 아래 이미지는 윈도우에 집중 켜놨다가 오랜만에 들어갔더니 저랬음;; 
  - <img width="256" alt="스크린샷 2024-10-22 오전 12 40 12" src="https://github.com/user-attachments/assets/e217e615-36f6-47ff-a19e-f90ef0d90093">
- 별개로 dialog 뜰 때마다 width: 100% 이여서 여백도 살짝 줌
  - 아래 이미지는 width 95%로 변경한 거
  - <img width="256" alt="스크린샷 2024-10-22 오전 12 40 12" src="https://github.com/user-attachments/assets/b8d40fd3-5cd4-4819-b715-7cca9b99c28d">


## 체크리스트

- [x] Code Review 요청
- [x] Label 설정
