### PR TITLE
fix: 윈도우 release 실패 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,7 @@ jobs:
       - name: install dependencies
         run: yarn install
       - name: set api endpoint
+        shell: bash
         run: |
           if [[ "${{ github.event.inputs.tag }}" == *"qa"* ]]; then
             echo "VITE_API_SERVER_URL=${{ secrets.VITE_DEV_API_SERVER_URL }}" >> $GITHUB_ENV


### PR DESCRIPTION
## 작업 내용

- windows 배포 스크립트는 `runs-on: windows-latest`에서 실행되다보니
- 기본이 power shell 환경임. 특정 스크립트만 bash 환경에서 실행되도록 수정해봄 

## 체크리스트

- [ ] Code Review 요청
- [ ] Label 설정
