### PR TITLE
fix: 뽀모도로 로그 중복 요청 이슈 수정

### DIFF
--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -22,12 +22,14 @@ const electronAPI: IElectronAPI = {
   startRest: () => ipcRenderer.invoke('start-rest'),
   endPomodoro: (reason) => ipcRenderer.invoke('end-pomodoro', reason),
 
-  onTickPomodoro: (callback) =>
-    ipcRenderer.on('tick-pomodoro', (_, cycles, time) => callback(cycles, time)),
-  onEndPomodoro: (callback) =>
-    ipcRenderer.on('end-pomodoro', (_, cycles, reason) => callback(cycles, reason)),
-  onOnceExceedGoalTime: (callback) =>
-    ipcRenderer.on('once-exceed-goal-time', (_, mode) => callback(mode)),
+  onTickPomodoro: (callback) => ipcRenderer.on('tick-pomodoro', callback),
+  offTickPomodoro: (callback) => ipcRenderer.off('tick-pomodoro', callback),
+
+  onEndPomodoro: (callback) => ipcRenderer.on('end-pomodoro', callback),
+  offEndPomodoro: (callback) => ipcRenderer.off('end-pomodoro', callback),
+
+  onOnceExceedGoalTime: (callback) => ipcRenderer.on('once-exceed-goal-time', callback),
+  offOnceExceedGoalTime: (callback) => ipcRenderer.off('once-exceed-goal-time', callback),
 };
 
 contextBridge.exposeInMainWorld('electronAPI', electronAPI);

--- a/src/shared/type/electron.ts
+++ b/src/shared/type/electron.ts
@@ -6,6 +6,21 @@ import {
   PomodoroTime,
 } from './pomodoro';
 
+export type TickPomodoroCallback = (
+  event: Electron.IpcRendererEvent,
+  cycles: PomodoroCycle[],
+  time: PomodoroTime,
+) => void;
+export type EndPomodoroCallback = (
+  event: Electron.IpcRendererEvent,
+  cycles: PomodoroCycle[],
+  reason: PomodoroEndReason,
+) => void;
+export type OnceExceedGoalTimeCallback = (
+  event: Electron.IpcRendererEvent,
+  mode: PomodoroMode,
+) => void;
+
 // @see: https://www.electronjs.org/docs/latest/tutorial/context-isolation#usage-with-typescript
 export interface IElectronAPI {
   showWindow: () => void;
@@ -24,7 +39,10 @@ export interface IElectronAPI {
   startRest: () => Promise<void>;
   endPomodoro: (reason: PomodoroEndReason) => Promise<void>;
 
-  onTickPomodoro: (callback: (cycles: PomodoroCycle[], time: PomodoroTime) => void) => void;
-  onEndPomodoro: (callback: (cycles: PomodoroCycle[], reason: PomodoroEndReason) => void) => void;
-  onOnceExceedGoalTime: (callback: (mode: PomodoroMode) => void) => void;
+  onTickPomodoro: (callback: TickPomodoroCallback) => void;
+  offTickPomodoro: (callback: TickPomodoroCallback) => void;
+  onEndPomodoro: (callback: EndPomodoroCallback) => void;
+  offEndPomodoro: (callback: EndPomodoroCallback) => void;
+  onOnceExceedGoalTime: (callback: OnceExceedGoalTimeCallback) => void;
+  offOnceExceedGoalTime: (callback: OnceExceedGoalTimeCallback) => void;
 }


### PR DESCRIPTION

## 작업 내용

- main process에서 뽀모도로 종료 이벤트를 보내면
- 이벤트 리스너를 통해 기록을 서버에 보냄
- 그런데 ipcRenderer에 대한 이벤트 리스너 등록만 있고
- 리스너 해제는 구현하지 않아 중복으로 요청을 보냄
- 이를 해결하기 위해 이벤트 리스너 해제 로직을 추가함


## 체크리스트

- [x] Code Review 요청
- [x] Label 설정
